### PR TITLE
docs: 約定回避設計を反映

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,19 @@ Claude 向けクイックリファレンス。
 
 ### 目的
 
-トレードで勝つことではなく、**条件を満たし続けること**を自動化する。
+**約定させずに板に居続けること**を自動化する。
+
+```
+約定 = 失敗
+```
+
+| 項目 | 方針 |
+|------|------|
+| 約定 | **しない**（手数料ゼロ、FRリスクゼロ） |
+| 建玉 | **持たない**（清算リスクゼロ） |
+| 距離 | 10bps以内だが約定しない位置 |
+
+### 報酬条件
 
 | 報酬 | 条件 | Bot の役割 |
 |------|------|-----------|
@@ -50,8 +62,7 @@ standx_mm_bot/
 │   │   └── websocket.py   # WebSocket
 │   ├── core/
 │   │   ├── order.py       # 注文管理
-│   │   ├── position.py    # ポジション管理
-│   │   └── risk.py        # リスク制御
+│   │   └── escape.py      # 約定回避ロジック
 │   └── strategy/
 │       └── maker.py       # Maker戦略
 ├── tests/
@@ -87,10 +98,10 @@ make format
 
 # 例
 feat(ws): WebSocket接続を実装 (issue#2)
-fix(order): 再発注ロジックを修正 (issue#3)
+fix(escape): 約定回避ロジックを修正 (issue#3)
 ```
 
-**Scope**: `auth`, `ws`, `order`, `position`, `risk`, `config`, `docs`
+**Scope**: `auth`, `ws`, `order`, `escape`, `config`, `docs`
 
 **禁止事項**:
 - main ブランチへの直接プッシュ
@@ -153,7 +164,6 @@ WS: wss://perps.standx.com/ws-stream/v1
 | 注文発注 | `POST /api/new_order` |
 | 注文キャンセル | `POST /api/cancel_order` |
 | 未決注文 | `GET /api/query_open_orders` |
-| ポジション | `GET /api/query_positions` |
 
 ### WebSocket チャンネル
 
@@ -161,11 +171,18 @@ WS: wss://perps.standx.com/ws-stream/v1
 |-----------|------|------|
 | `price` | 不要 | mark_price |
 | `order` | 必要 | 注文状態 |
-| `position` | 必要 | ポジション |
+| `depth_book` | 不要 | 板情報（約定回避判断用） |
 
 ---
 
 ## Bot ロジック要点
+
+### 設計思想
+
+```
+価格が近づいてきたら → 逃げる
+価格が離れたら → 戻る
+```
 
 ### bps 計算
 
@@ -173,11 +190,23 @@ WS: wss://perps.standx.com/ws-stream/v1
 distance_bps = abs(order_price - mark_price) / mark_price * 10000
 ```
 
-### 再配置トリガー
+### 約定回避ロジック
 
-1. 距離が 10bps を超えそう
-2. mark_price が閾値以上変動
-3. 注文が約定
+```python
+# 価格が注文に近づいたら逃げる
+if distance_to_order < ESCAPE_THRESHOLD_BPS:  # 3bps
+    cancel_order() or move_to_outer(15bps)
+
+# 価格が離れたら戻る
+if distance_to_order > RETURN_THRESHOLD_BPS:
+    move_to_target(8bps)
+```
+
+### 優先順位
+
+1. **約定回避** — 最優先。建玉を持たない
+2. **10bps維持** — Uptime条件を満たす
+3. **空白時間最小化** — 板に常に存在
 
 ### 空白時間最小化
 
@@ -187,13 +216,6 @@ distance_bps = abs(order_price - mark_price) / mark_price * 10000
 ```
 
 キャンセル→発注ではなく、発注→キャンセルの順序。
-
-### リスク制御
-
-```python
-if abs(net_position) > MAX_NET_POSITION:
-    # 偏り側の注文を停止
-```
 
 ---
 


### PR DESCRIPTION
## 概要

README.md と CLAUDE.md に約定回避設計を反映。

## 変更内容

- 「約定 = 失敗」の設計思想を明記
- 約定回避ロジック（逃げる/戻る）を追加
- ディレクトリ構成: position.py, risk.py → escape.py
- 設定パラメータ: ESCAPE_THRESHOLD_BPS 追加

## チェックリスト

- [x] README.md 更新
- [x] CLAUDE.md 更新

Closes #1