### PR TITLE
Docker環境整備（開発・本番をDockerに統一）

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+.venv/
+venv/
+ENV/
+
+# Test & Coverage
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Environment
+.env.local
+
+# Documentation drafts
+*.draft.md
+
+# macOS
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -493,7 +493,7 @@ issue#2のWebSocket接続機能を実装しました。
 
 ## テスト方法
 ```bash
-python -m pytest tests/test_websocket.py
+make test
 ```
 
 ## チェックリスト

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# ===== Base Stage =====
+FROM python:3.12-slim as base
+WORKDIR /app
+
+# システムパッケージ更新
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# ===== Development Stage =====
+FROM base as dev
+
+# 依存関係ファイルをコピー
+COPY pyproject.toml README.md ./
+
+# 開発用依存関係をインストール
+RUN pip install --no-cache-dir -e ".[dev]"
+
+# ソースコードをコピー
+COPY . .
+
+# 非rootユーザー作成
+RUN useradd -m -u 1000 botuser && chown -R botuser:botuser /app
+USER botuser
+
+CMD ["python", "-m", "standx_mm_bot"]
+
+# ===== Production Stage =====
+FROM base as prod
+
+# 依存関係ファイルをコピー
+COPY pyproject.toml README.md ./
+
+# 本番用依存関係のみインストール
+RUN pip install --no-cache-dir .
+
+# ソースコードをコピー
+COPY src/ ./src/
+
+# 非rootユーザー作成
+RUN useradd -m -u 1000 botuser && chown -R botuser:botuser /app
+USER botuser
+
+CMD ["python", "-m", "standx_mm_bot"]

--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,56 @@
-.PHONY: run test typecheck lint format check install clean
+.PHONY: up down test test-cov typecheck lint format check logs clean build-prod up-prod restart-prod
 
-# Bot起動
-run:
-	python -m standx_mm_bot
+# 開発環境: Bot起動
+up:
+	docker compose up -d
+
+# 開発環境: Bot停止
+down:
+	docker compose down
 
 # テスト実行
 test:
-	pytest
+	docker compose run --rm bot pytest
 
 # テスト (カバレッジ付き)
 test-cov:
-	pytest --cov --cov-report=term-missing
+	docker compose run --rm bot pytest --cov --cov-report=term-missing
 
 # 型チェック
 typecheck:
-	mypy src
+	docker compose run --rm bot mypy src
 
 # Lint
 lint:
-	ruff check src tests
+	docker compose run --rm bot ruff check src tests
 
 # フォーマット
 format:
-	ruff format src tests
-	ruff check --fix src tests
+	docker compose run --rm bot ruff format src tests
+	docker compose run --rm bot ruff check --fix src tests
 
 # 全チェック (lint + typecheck + test)
 check: lint typecheck test
 
-# 依存関係インストール
-install:
-	pip install -e ".[dev]"
+# ログ確認
+logs:
+	docker compose logs -f bot
 
-# キャッシュ削除
+# クリーンアップ
 clean:
+	docker compose down -v
 	rm -rf .pytest_cache .mypy_cache .ruff_cache .coverage htmlcov
 	find . -type d -name "__pycache__" -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
+
+# 本番環境: イメージビルド
+build-prod:
+	docker compose -f compose.prod.yaml build
+
+# 本番環境: Bot起動
+up-prod:
+	docker compose -f compose.prod.yaml up -d
+
+# 本番環境: Bot再起動
+restart-prod:
+	docker compose -f compose.prod.yaml restart

--- a/README.md
+++ b/README.md
@@ -75,12 +75,9 @@ StandX は「板に居続けること」に報酬が出る Perp DEX。このBot�
 git clone https://github.com/zomians/standx_mm_bot.git
 cd standx_mm_bot
 
-# 仮想環境作成
-python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
-
-# 依存関係インストール
-pip install -e ".[dev]"
+# Docker と Docker Compose がインストールされていることを確認
+docker --version
+docker compose version
 ```
 
 ### 2. 環境変数設定
@@ -108,10 +105,13 @@ ESCAPE_THRESHOLD_BPS=3        # この距離まで近づいたら逃げる
 
 ```bash
 # Bot 起動
-python -m standx_mm_bot
+make up
 
-# または
-make run
+# ログ確認
+make logs
+
+# Bot 停止
+make down
 ```
 
 ---
@@ -151,11 +151,17 @@ standx_mm_bot/
 
 ## よく使うコマンド
 
-### 開発
+### 開発環境
 
 ```bash
 # Bot 起動
-make run
+make up
+
+# Bot 停止
+make down
+
+# ログ確認
+make logs
 
 # テスト実行
 make test
@@ -171,6 +177,22 @@ make format
 
 # 全チェック (lint + typecheck + test)
 make check
+
+# クリーンアップ
+make clean
+```
+
+### 本番環境
+
+```bash
+# イメージビルド
+make build-prod
+
+# Bot 起動
+make up-prod
+
+# Bot 再起動
+make restart-prod
 ```
 
 ### Git

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,8 @@
+services:
+  bot:
+    build:
+      context: .
+      target: prod
+    env_file:
+      - .env
+    restart: unless-stopped

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  bot:
+    build:
+      context: .
+      target: dev
+    volumes:
+      - ./src:/app/src:ro
+      - ./tests:/app/tests:ro


### PR DESCRIPTION
## Summary

- Docker開発環境を整備し、開発・本番の両方をDockerに統一
- Dockerfile（dev/prodマルチステージビルド）、compose.yaml、compose.prod.yamlを追加
- Makefileを全面改訂し、全コマンドをDocker経由に変更
- README.md/CONTRIBUTING.mdをDocker前提の手順に更新

## Test plan

- [x] `make up` でコンテナが起動する
- [x] `make test` でpytestが実行される
- [x] `make down` でコンテナが停止する
- [x] `make typecheck` で型チェックが実行される
- [x] `make lint` でLintが実行される
- [ ] Issue #12完了後、実際のBotコードで動作確認

Closes #23