### PR TITLE
feat(tools): 残高表示機能を追加（StandX + Solana）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down test test-cov typecheck lint format format-check check logs clean build-prod up-prod restart-prod wallet price orders position status
+.PHONY: up down test test-cov typecheck lint format format-check check logs clean build-prod up-prod restart-prod wallet price orders position balance status
 
 # 開発環境: Bot起動
 up:
@@ -76,6 +76,10 @@ orders:
 position:
 	@echo "Fetching current position..."
 	docker compose run --rm bot python scripts/read_api.py position
+
+balance:
+	@echo "Fetching balance (StandX + Solana)..."
+	docker compose run --rm bot python scripts/read_api.py balance
 
 status:
 	@echo "Fetching all status..."

--- a/src/standx_mm_bot/client/http.py
+++ b/src/standx_mm_bot/client/http.py
@@ -324,3 +324,23 @@ class StandXHTTPClient:
         """
         path = f"/api/query_positions?symbol={symbol}"
         return await self._request("GET", path)
+
+    async def get_balance(self) -> dict[str, Any]:
+        """
+        残高情報を取得.
+
+        Returns:
+            dict: 残高情報
+                - isolated_balance: 隔離ウォレット合計
+                - isolated_upnl: 隔離未実現損益
+                - cross_balance: クロス自由残高
+                - cross_margin: クロス証拠金使用額
+                - cross_upnl: クロス未実現損益
+                - locked: オーダーロック額
+                - cross_available: 利用可能額
+                - balance: 総資産
+                - upnl: 合計未実現損益
+                - equity: アカウント資産額
+                - pnl_freeze: 24時間実現損益
+        """
+        return await self._request("GET", "/api/query_balance")

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -202,6 +202,31 @@ async def test_get_position(config: Settings) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_balance(config: Settings) -> None:
+    """残高情報取得が正しく動作することを確認."""
+    with aioresponses() as mocked:
+        # モックレスポンスを設定
+        mocked.get(
+            "https://perps.standx.com/api/query_balance",
+            payload={
+                "equity": 10000.0,
+                "cross_available": 8000.0,
+                "upnl": 500.0,
+                "locked": 2000.0,
+                "balance": 9500.0,
+            },
+        )
+
+        async with StandXHTTPClient(config, jwt_token="test_jwt_token") as client:
+            response = await client.get_balance()
+
+        assert response["equity"] == 10000.0
+        assert response["cross_available"] == 8000.0
+        assert response["upnl"] == 500.0
+        assert response["locked"] == 2000.0
+
+
+@pytest.mark.asyncio
 async def test_authentication_error(config: Settings) -> None:
     """認証エラー (401) が正しく処理されることを確認."""
     with aioresponses() as mocked:


### PR DESCRIPTION
## 概要

issue#40の残高表示機能を実装しました。`make balance` および `make status` でStandX取引所とSolanaウォレットの残高を確認できます。

## 変更内容

### 1. StandX残高取得（src/standx_mm_bot/client/http.py）
- `StandXHTTPClient.get_balance()` メソッド追加
- `/api/query_balance` エンドポイント
- equity, available, upnl, locked を取得

### 2. Solana残高取得（scripts/read_api.py）
- `get_solana_balance()` 関数追加
- Solana RPC APIを使用
- SOL残高とUSDC残高を取得

### 3. 残高表示機能（scripts/read_api.py）
- `get_balance()` 関数: StandX + Solana残高を表示
- `get_status()` 関数: 残高表示を統合
- 404エラーハンドリング（未デポジット時は残高ゼロ表示）
- Rich UIで見やすく表示

### 4. Makefile更新
- `make balance` コマンド追加
- `.PHONY` に balance 追加

### 5. テスト追加
- `test_http.py::test_get_balance` 追加
- モックを使用したユニットテスト

## テスト方法

\`\`\`bash
# 残高のみ表示
make balance

# 全状態表示（残高含む）
make status

# ユニットテスト
docker compose run --rm bot pytest tests/test_http.py::test_get_balance -v
\`\`\`

## 動作確認結果

- ✅ `make balance` 成功（404エラーを適切にハンドリング）
- ✅ `make status` 成功（残高、価格、注文、ポジション全て表示）
- ✅ ユニットテスト 13/13 通過
- ✅ 型チェック通過
- ✅ Lint通過

## チェックリスト

- [x] StandX残高取得メソッド実装
- [x] Solana残高取得機能実装
- [x] read_api.py更新
- [x] Makefile更新
- [x] テスト追加
- [x] 型チェック・Lint通過
- [x] 動作確認完了
- [x] AI署名削除（CONTRIBUTING.md準拠）

Closes #40