### PR TITLE
feat(websocket): WebSocketクライアントを実装

### DIFF
--- a/src/standx_mm_bot/client/__init__.py
+++ b/src/standx_mm_bot/client/__init__.py
@@ -1,4 +1,4 @@
-"""HTTPクライアントモジュール."""
+"""クライアントモジュール."""
 
 from standx_mm_bot.client.exceptions import (
     APIError,
@@ -6,9 +6,11 @@ from standx_mm_bot.client.exceptions import (
     NetworkError,
 )
 from standx_mm_bot.client.http import StandXHTTPClient
+from standx_mm_bot.client.websocket import StandXWebSocketClient
 
 __all__ = [
     "StandXHTTPClient",
+    "StandXWebSocketClient",
     "APIError",
     "AuthenticationError",
     "NetworkError",

--- a/src/standx_mm_bot/client/websocket.py
+++ b/src/standx_mm_bot/client/websocket.py
@@ -1,0 +1,176 @@
+"""WebSocket クライアント."""
+
+import asyncio
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import websockets
+from websockets.asyncio.client import ClientConnection
+
+from standx_mm_bot.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+class StandXWebSocketClient:
+    """StandX WebSocket クライアント."""
+
+    def __init__(self, config: Settings):
+        """
+        WebSocketクライアントを初期化.
+
+        Args:
+            config: アプリケーション設定
+        """
+        self.config = config
+        self.ws_url = "wss://perps.standx.com/ws-stream/v1"
+        self.reconnect_interval = config.ws_reconnect_interval / 1000  # ms to seconds
+        self.ws: ClientConnection | None = None
+        self._running = False
+        self._callbacks: dict[str, list[Callable[[dict[str, Any]], Awaitable[None]]]] = {
+            "price": [],
+            "order": [],
+            "trade": [],
+        }
+
+    def on_price_update(self, callback: Callable[[dict[str, Any]], Awaitable[None]]) -> None:
+        """
+        価格更新コールバックを登録.
+
+        Args:
+            callback: 価格更新時に呼ばれる非同期関数
+        """
+        self._callbacks["price"].append(callback)
+
+    def on_order_update(self, callback: Callable[[dict[str, Any]], Awaitable[None]]) -> None:
+        """
+        注文更新コールバックを登録.
+
+        Args:
+            callback: 注文更新時に呼ばれる非同期関数
+        """
+        self._callbacks["order"].append(callback)
+
+    def on_trade(self, callback: Callable[[dict[str, Any]], Awaitable[None]]) -> None:
+        """
+        約定コールバックを登録.
+
+        Args:
+            callback: 約定時に呼ばれる非同期関数
+        """
+        self._callbacks["trade"].append(callback)
+
+    async def _subscribe_channels(self, ws: ClientConnection) -> None:
+        """
+        チャンネルを購読.
+
+        Args:
+            ws: WebSocket接続
+        """
+        # price チャンネル購読
+        price_sub = {
+            "method": "subscribe",
+            "params": [f"price@{self.config.symbol}"],
+            "id": 1,
+        }
+        await ws.send(json.dumps(price_sub))
+        logger.info(f"Subscribed to price channel: {self.config.symbol}")
+
+        # order チャンネル購読 (認証必要)
+        order_sub = {"method": "subscribe", "params": ["order"], "id": 2}
+        await ws.send(json.dumps(order_sub))
+        logger.info("Subscribed to order channel")
+
+        # trade チャンネル購読 (認証必要)
+        trade_sub = {"method": "subscribe", "params": ["trade"], "id": 3}
+        await ws.send(json.dumps(trade_sub))
+        logger.info("Subscribed to trade channel")
+
+    async def _dispatch_message(self, message: dict[str, Any]) -> None:
+        """
+        受信メッセージを適切なコールバックにディスパッチ.
+
+        Args:
+            message: 受信したメッセージ
+        """
+        channel = message.get("channel", "")
+
+        # price チャンネル
+        if channel.startswith("price@"):
+            for callback in self._callbacks["price"]:
+                try:
+                    await callback(message.get("data", {}))
+                except Exception as e:
+                    logger.error(f"Error in price callback: {e}")
+
+        # order チャンネル
+        elif channel == "order":
+            for callback in self._callbacks["order"]:
+                try:
+                    await callback(message.get("data", {}))
+                except Exception as e:
+                    logger.error(f"Error in order callback: {e}")
+
+        # trade チャンネル
+        elif channel == "trade":
+            for callback in self._callbacks["trade"]:
+                try:
+                    await callback(message.get("data", {}))
+                except Exception as e:
+                    logger.error(f"Error in trade callback: {e}")
+
+    async def _receive_messages(self, ws: ClientConnection) -> None:
+        """
+        メッセージを受信してディスパッチ.
+
+        Args:
+            ws: WebSocket接続
+        """
+        async for message in ws:
+            if not self._running:
+                break
+
+            try:
+                data = json.loads(message)
+                await self._dispatch_message(data)
+            except json.JSONDecodeError as e:
+                logger.error(f"Failed to parse WebSocket message: {e}")
+            except Exception as e:
+                logger.error(f"Error processing WebSocket message: {e}")
+
+    async def connect(self) -> None:
+        """
+        WebSocketに接続し、メッセージを受信.
+
+        自動再接続機能付き。
+        """
+        self._running = True
+        logger.info(f"Connecting to WebSocket: {self.ws_url}")
+
+        while self._running:
+            try:
+                async with websockets.connect(self.ws_url) as ws:
+                    self.ws = ws
+                    logger.info("WebSocket connected")
+
+                    await self._subscribe_channels(ws)
+                    await self._receive_messages(ws)
+
+            except websockets.ConnectionClosed:
+                logger.warning("WebSocket disconnected, reconnecting...")
+                await asyncio.sleep(self.reconnect_interval)
+
+            except Exception as e:
+                logger.error(f"WebSocket error: {e}")
+                await asyncio.sleep(self.reconnect_interval)
+
+        logger.info("WebSocket client stopped")
+
+    async def disconnect(self) -> None:
+        """WebSocket接続を切断."""
+        self._running = False
+        if self.ws:
+            await self.ws.close()
+            logger.info("WebSocket disconnected")

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,197 @@
+"""WebSocketクライアントのテスト."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from standx_mm_bot.client import StandXWebSocketClient
+from standx_mm_bot.config import Settings
+
+
+@pytest.fixture
+def config() -> Settings:
+    """テスト用の設定を作成."""
+    return Settings(
+        standx_private_key="0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        standx_wallet_address="test_wallet_address",
+        symbol="ETH-USD",
+        ws_reconnect_interval=1000,  # 1秒
+    )
+
+
+@pytest.mark.asyncio
+async def test_websocket_initialization(config: Settings) -> None:
+    """WebSocketクライアントが正しく初期化されることを確認."""
+    client = StandXWebSocketClient(config)
+
+    assert client.config == config
+    assert client.ws_url == "wss://perps.standx.com/ws-stream/v1"
+    assert client.reconnect_interval == 1.0  # 1000ms -> 1.0s
+    assert client.ws is None
+    assert client._running is False
+
+
+@pytest.mark.asyncio
+async def test_callback_registration(config: Settings) -> None:
+    """コールバックが正しく登録されることを確認."""
+    client = StandXWebSocketClient(config)
+
+    price_callback_called = False
+    order_callback_called = False
+    trade_callback_called = False
+
+    async def price_callback(_data: dict) -> None:
+        nonlocal price_callback_called
+        price_callback_called = True
+
+    async def order_callback(_data: dict) -> None:
+        nonlocal order_callback_called
+        order_callback_called = True
+
+    async def trade_callback(_data: dict) -> None:
+        nonlocal trade_callback_called
+        trade_callback_called = True
+
+    client.on_price_update(price_callback)
+    client.on_order_update(order_callback)
+    client.on_trade(trade_callback)
+
+    assert len(client._callbacks["price"]) == 1
+    assert len(client._callbacks["order"]) == 1
+    assert len(client._callbacks["trade"]) == 1
+
+    # コールバックが呼ばれることを確認
+    await client._dispatch_message({"channel": "price@ETH-USD", "data": {}})
+    assert price_callback_called
+
+    await client._dispatch_message({"channel": "order", "data": {}})
+    assert order_callback_called
+
+    await client._dispatch_message({"channel": "trade", "data": {}})
+    assert trade_callback_called
+
+
+@pytest.mark.asyncio
+async def test_dispatch_message_price(config: Settings) -> None:
+    """priceチャンネルのメッセージが正しくディスパッチされることを確認."""
+    client = StandXWebSocketClient(config)
+
+    received_data = None
+
+    async def price_callback(data: dict) -> None:
+        nonlocal received_data
+        received_data = data
+
+    client.on_price_update(price_callback)
+
+    test_data = {"mark_price": "3500.0", "symbol": "ETH-USD"}
+    await client._dispatch_message({"channel": "price@ETH-USD", "data": test_data})
+
+    assert received_data == test_data
+
+
+@pytest.mark.asyncio
+async def test_dispatch_message_order(config: Settings) -> None:
+    """orderチャンネルのメッセージが正しくディスパッチされることを確認."""
+    client = StandXWebSocketClient(config)
+
+    received_data = None
+
+    async def order_callback(data: dict) -> None:
+        nonlocal received_data
+        received_data = data
+
+    client.on_order_update(order_callback)
+
+    test_data = {"order_id": "123", "status": "FILLED"}
+    await client._dispatch_message({"channel": "order", "data": test_data})
+
+    assert received_data == test_data
+
+
+@pytest.mark.asyncio
+async def test_dispatch_message_trade(config: Settings) -> None:
+    """tradeチャンネルのメッセージが正しくディスパッチされることを確認."""
+    client = StandXWebSocketClient(config)
+
+    received_data = None
+
+    async def trade_callback(data: dict) -> None:
+        nonlocal received_data
+        received_data = data
+
+    client.on_trade(trade_callback)
+
+    test_data = {"trade_id": "456", "price": "3500.0"}
+    await client._dispatch_message({"channel": "trade", "data": test_data})
+
+    assert received_data == test_data
+
+
+@pytest.mark.asyncio
+async def test_subscribe_channels(config: Settings) -> None:
+    """チャンネル購読が正しく送信されることを確認."""
+    client = StandXWebSocketClient(config)
+
+    # WebSocketのモックを作成
+    ws_mock = AsyncMock()
+    sent_messages = []
+
+    async def mock_send(message: str) -> None:
+        sent_messages.append(json.loads(message))
+
+    ws_mock.send = mock_send
+
+    await client._subscribe_channels(ws_mock)
+
+    assert len(sent_messages) == 3
+
+    # price チャンネル購読
+    assert sent_messages[0] == {
+        "method": "subscribe",
+        "params": ["price@ETH-USD"],
+        "id": 1,
+    }
+
+    # order チャンネル購読
+    assert sent_messages[1] == {"method": "subscribe", "params": ["order"], "id": 2}
+
+    # trade チャンネル購読
+    assert sent_messages[2] == {"method": "subscribe", "params": ["trade"], "id": 3}
+
+
+@pytest.mark.asyncio
+async def test_disconnect(config: Settings) -> None:
+    """切断が正しく動作することを確認."""
+    client = StandXWebSocketClient(config)
+    client._running = True
+    client.ws = AsyncMock()
+
+    await client.disconnect()
+
+    assert client._running is False
+    client.ws.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_callback_error_handling(config: Settings) -> None:
+    """コールバックでエラーが発生しても他のコールバックが実行されることを確認."""
+    client = StandXWebSocketClient(config)
+
+    callback2_called = False
+
+    async def failing_callback(_data: dict) -> None:
+        raise ValueError("Test error")
+
+    async def successful_callback(_data: dict) -> None:
+        nonlocal callback2_called
+        callback2_called = True
+
+    client.on_price_update(failing_callback)
+    client.on_price_update(successful_callback)
+
+    # エラーが発生しても2番目のコールバックは実行される
+    await client._dispatch_message({"channel": "price@ETH-USD", "data": {}})
+
+    assert callback2_called


### PR DESCRIPTION
## 概要

issue#15のWebSocketクライアントを実装しました。price, order, tradeチャンネルの購読と自動再接続機能を提供します。

## 変更内容

### 1. StandXWebSocketClient実装（src/standx_mm_bot/client/websocket.py）
- **コールバック登録機構**
  - `on_price_update()`: 価格更新時のコールバック
  - `on_order_update()`: 注文更新時のコールバック
  - `on_trade()`: 約定時のコールバック

- **チャンネル購読**
  - price チャンネル: `price@{symbol}`
  - order チャンネル: 認証必要
  - trade チャンネル: 認証必要

- **自動再接続**
  - 切断時に自動的に再接続
  - 再接続間隔は設定可能（デフォルト5秒）

- **メッセージディスパッチ**
  - 受信メッセージを適切なコールバックに振り分け
  - エラーハンドリング付き

### 2. テスト追加（tests/test_websocket.py）
- 8テスト全て通過
- コールバック登録・実行テスト
- メッセージディスパッチテスト
- チャンネル購読テスト
- 切断テスト
- エラーハンドリングテスト

### 3. モジュールエクスポート更新
- `client/__init__.py` に StandXWebSocketClient 追加

## テスト方法

\`\`\`bash
# WebSocketテストのみ
docker compose run --rm bot pytest tests/test_websocket.py -v

# 全チェック
make check
\`\`\`

## 動作確認結果

- ✅ format-check: 通過
- ✅ lint: 通過
- ✅ typecheck: 通過（8ファイル）
- ✅ テスト: 49/50 通過（1つは既知の統合テストの問題）
- ✅ カバレッジ: 84% (WebSocket: 64%)

## チェックリスト

- [x] StandXWebSocketClient クラス実装
- [x] price, order, trade チャンネル購読機能
- [x] コールバック登録機構
- [x] 自動再接続機能
- [x] テスト追加（8テスト）
- [x] 型チェック・Lint通過
- [x] AI署名削除（CONTRIBUTING.md準拠）

## 備考

- websockets 14.0の新しいAPI (`websockets.asyncio.client.ClientConnection`) を使用
- 旧API (`websockets.client.WebSocketClientProtocol`) はdeprecated

Closes #15