### PR TITLE
feat(tools): シンボル切り替えコマンドとドキュメント整備

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,20 @@ standx_mm_bot/
 
 ```bash
 # 起動
-make run
+make up
+
+# ETH-USDで起動
+make up-eth
+
+# BTC-USDで起動
+make up-btc
+
+# シンボル切り替え
+make switch-eth  # ETH-USD
+make switch-btc  # BTC-USD
+
+# 設定確認
+make config
 
 # テスト
 make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down test test-cov typecheck lint format format-check check logs clean build-prod up-prod restart-prod wallet price orders position balance status
+.PHONY: up down test test-cov typecheck lint format format-check check logs clean build-prod up-prod restart-prod wallet price orders position balance status switch-eth switch-btc up-eth up-btc config
 
 # 開発環境: Bot起動
 up:
@@ -84,3 +84,32 @@ balance:
 status:
 	@echo "Fetching all status..."
 	docker compose run --rm bot python scripts/read_api.py status
+
+# シンボル切り替え: ETH-USD
+switch-eth:
+	@if [ ! -f .env ]; then echo "Error: .env file not found. Run 'cp .env.example .env' first."; exit 1; fi
+	@sed -i.bak 's/^SYMBOL=.*/SYMBOL=ETH-USD/' .env && rm -f .env.bak
+	@echo "✅ Switched to ETH-USD"
+	@grep "^SYMBOL=" .env
+
+# シンボル切り替え: BTC-USD
+switch-btc:
+	@if [ ! -f .env ]; then echo "Error: .env file not found. Run 'cp .env.example .env' first."; exit 1; fi
+	@sed -i.bak 's/^SYMBOL=.*/SYMBOL=BTC-USD/' .env && rm -f .env.bak
+	@echo "✅ Switched to BTC-USD"
+	@grep "^SYMBOL=" .env
+
+# ETH-USDで起動
+up-eth: switch-eth up
+
+# BTC-USDで起動
+up-btc: switch-btc up
+
+# 現在の設定確認（秘密鍵・アドレスは表示しない）
+config:
+	@echo "=== Current Configuration ==="
+	@if [ -f .env ]; then \
+		cat .env | grep -v "PRIVATE_KEY\|WALLET_ADDRESS" | grep -v "^#" | grep -v "^$$"; \
+	else \
+		echo "Error: .env file not found"; \
+	fi

--- a/README.md
+++ b/README.md
@@ -125,6 +125,25 @@ make logs
 make down
 ```
 
+### 4. シンボル切り替え（オプション）
+
+ETH-USDとBTC-USDを簡単に切り替えできます。
+
+```bash
+# ETH-USDで起動
+make up-eth
+
+# BTC-USDで起動
+make up-btc
+
+# シンボルのみ切り替え（起動なし）
+make switch-eth
+make switch-btc
+
+# 現在の設定確認
+make config
+```
+
 ---
 
 ## ディレクトリ構成
@@ -177,6 +196,9 @@ StandX APIのデータを確認するためのツールコマンドです：
 # ウォレット作成（初回のみ）
 make wallet
 
+# 現在の設定確認
+make config
+
 # 現在の価格を取得
 make price
 
@@ -191,6 +213,22 @@ make balance
 
 # すべてのステータスを取得
 make status
+```
+
+### シンボル切り替え
+
+```bash
+# ETH-USDに切り替え
+make switch-eth
+
+# BTC-USDに切り替え
+make switch-btc
+
+# ETH-USDで起動
+make up-eth
+
+# BTC-USDで起動
+make up-btc
 ```
 
 ### 開発環境


### PR DESCRIPTION
## 概要

ETH-USDとBTC-USDを簡単に切り替えるためのMakefileコマンドを追加し、ドキュメントを整備しました。

## 変更内容

### Makefile

1. **シンボル切り替えコマンド**
   - `make switch-eth`: .envのSYMBOLをETH-USDに変更
   - `make switch-btc`: .envのSYMBOLをBTC-USDに変更
   - `make up-eth`: ETH-USDで起動
   - `make up-btc`: BTC-USDで起動
   - `make config`: 現在の設定を表示（秘密鍵・アドレスは非表示）

2. **エラーハンドリング**
   - .envファイルが存在しない場合はエラーメッセージ表示
   - sedコマンドでクロスプラットフォーム対応（.bakファイル自動削除）

### README.md

1. **クイックスタートにシンボル切り替えセクション追加**
   - ETH/BTC切り替え方法を説明
   
2. **よく使うコマンドセクション更新**
   - ツールコマンドに`make config`追加
   - シンボル切り替えコマンドを追加

### CLAUDE.md

- よく使うコマンドにシンボル切り替えコマンドを追加

## 動作確認

```bash
# 設定確認
$ make config
=== Current Configuration ===
STANDX_CHAIN=solana
SYMBOL=ETH-USD
ORDER_SIZE=0.1
...

# BTC-USDに切り替え
$ make switch-btc
✅ Switched to BTC-USD
SYMBOL=BTC-USD

# ETH-USDに切り替え
$ make switch-eth
✅ Switched to ETH-USD
SYMBOL=ETH-USD
```

## 主要なポイント

- 🔄 ワンコマンドでシンボル切り替え
- 📋 現在の設定を簡単に確認可能
- 🔒 秘密鍵・アドレスは`make config`で非表示
- 🛡️ .envファイルの存在チェック

## 関連Issue

Closes #42