### PR TITLE
fix(scripts): dry_run削除漏れとテスト期待値を修正 (issue#61)

### DIFF
--- a/scripts/read_api.py
+++ b/scripts/read_api.py
@@ -401,9 +401,6 @@ async def main() -> None:
         # 設定読み込み
         config = Settings()
 
-        # dry_runを無効化（実際のAPIから読み取る）
-        config.dry_run = False
-
         async with StandXHTTPClient(config) as client:
             if command == "price":
                 await get_price(client, config.symbol)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,7 +43,7 @@ def test_settings_default_values() -> None:
     # デフォルト値の確認
     assert settings.standx_chain == "bsc"
     assert settings.symbol == "ETH-USD"
-    assert settings.order_size == 0.1
+    assert settings.order_size == 0.001
     assert settings.target_distance_bps == 8.0
     assert settings.escape_threshold_bps == 3.0
     assert settings.outer_escape_distance_bps == 15.0


### PR DESCRIPTION
## 概要

issue#59 で `dry_run` を完全削除した際の修正漏れと、関連するテスト期待値のずれを修正します。

Closes #61

---

## 変更内容

### 1. scripts/read_api.py
- **問題**: 404-405行目に `config.dry_run = False` が残っていた
- **修正**: 該当行を削除
- **理由**: issue#59 で `Settings` クラスから `dry_run` フィールドが削除されたため

### 2. tests/test_config.py
- **問題**: `order_size` の期待値が `0.1` のまま
- **修正**: 期待値を `0.001` に変更
- **理由**: `config.py` のデフォルト値が `0.001` に変更されたため

---

## テスト結果

```
✅ make test: 79 passed, 6 deselected
✅ make balance: 正常動作
✅ ruff format --check: OK
✅ ruff check: OK
✅ mypy: OK
```

---

## 原因分析

**発生時期**: 2026-01-22 17:34 (issue#59, commit `4d475c0`)

issue#59 で `dry_run` 完全削除時に、以下のファイルは修正されたが：
- ✅ `src/standx_mm_bot/config.py`
- ✅ `src/standx_mm_bot/client/http.py`
- ✅ `tests/test_http.py`

以下のファイルの修正が漏れた：
- ❌ `scripts/read_api.py`

---

## チェックリスト

- [x] テストが全てパス
- [x] 型チェック・Lintエラーなし
- [x] コミットメッセージが規約に準拠
- [x] Issue番号を記載
- [x] 動作確認済み（make balance）