### PR TITLE
feat(core): 注文管理を実装 (issue#17)

### DIFF
--- a/src/standx_mm_bot/client/http.py
+++ b/src/standx_mm_bot/client/http.py
@@ -263,7 +263,7 @@ class StandXHTTPClient:
             price: 注文価格
             size: 注文サイズ
             order_type: 注文タイプ (limit/market、小文字)
-            time_in_force: 注文有効期限 (gtc/ioc/fok)
+            time_in_force: 注文有効期限 (gtc/ioc/alo)
             reduce_only: ポジション縮小のみフラグ
 
         Returns:

--- a/src/standx_mm_bot/core/__init__.py
+++ b/src/standx_mm_bot/core/__init__.py
@@ -1,1 +1,5 @@
 """コアロジックモジュール."""
+
+from standx_mm_bot.core.order import OrderManager
+
+__all__ = ["OrderManager"]

--- a/src/standx_mm_bot/core/order.py
+++ b/src/standx_mm_bot/core/order.py
@@ -1,0 +1,235 @@
+"""注文管理モジュール."""
+
+import asyncio
+import logging
+from typing import Any, Literal
+
+from standx_mm_bot.client import StandXHTTPClient
+from standx_mm_bot.config import Settings
+from standx_mm_bot.models import Order, OrderStatus, OrderType, Side
+
+logger = logging.getLogger(__name__)
+
+
+class OrderManager:
+    """
+    注文管理クラス.
+
+    注文の発注・キャンセル・再配置を管理し、asyncio.Lockで競合を防止する。
+    """
+
+    def __init__(self, http_client: StandXHTTPClient, config: Settings):
+        """
+        OrderManagerを初期化.
+
+        Args:
+            http_client: StandX HTTPクライアント
+            config: アプリケーション設定
+        """
+        self.client = http_client
+        self.config = config
+        self._lock = asyncio.Lock()
+
+    async def place_order(
+        self,
+        side: Side,
+        price: float,
+        size: float,
+        time_in_force: str = "alo",
+    ) -> Order:
+        """
+        注文を発注.
+
+        Args:
+            side: 注文サイド (BUY/SELL)
+            price: 注文価格
+            size: 注文サイズ
+            time_in_force: 注文有効期限 (デフォルト: alo = Add Liquidity Only)
+
+        Returns:
+            Order: 発注された注文情報
+
+        Raises:
+            APIError: API呼び出しに失敗
+        """
+        async with self._lock:
+            logger.info(
+                f"Placing {side.value} order: price={price:.2f}, size={size}, "
+                f"time_in_force={time_in_force}"
+            )
+
+            response = await self.client.new_order(
+                symbol=self.config.symbol,
+                side=side.value.lower(),
+                price=price,
+                size=size,
+                order_type="limit",
+                time_in_force=time_in_force,
+                reduce_only=False,
+            )
+
+            order = self._parse_order_response(response, side, price, size)
+            logger.info(f"Order placed: order_id={order.id}, status={order.status}")
+
+            return order
+
+    async def cancel_order(self, order_id: str) -> None:
+        """
+        注文をキャンセル.
+
+        Args:
+            order_id: キャンセルする注文ID
+
+        Raises:
+            APIError: API呼び出しに失敗
+        """
+        async with self._lock:
+            logger.info(f"Cancelling order: order_id={order_id}")
+
+            await self.client.cancel_order(
+                order_id=order_id,
+                symbol=self.config.symbol,
+            )
+
+            logger.info(f"Order cancelled: order_id={order_id}")
+
+    async def reposition_order(
+        self,
+        old_order_id: str,
+        new_price: float,
+        side: Side,
+        size: float,
+        strategy: Literal["place_first", "cancel_first"] = "place_first",
+    ) -> Order:
+        """
+        注文を再配置.
+
+        Args:
+            old_order_id: 旧注文ID
+            new_price: 新しい価格
+            side: 注文サイド
+            size: 注文サイズ
+            strategy: 再配置戦略
+                - "place_first": 新規注文発注 → 確認 → 旧注文キャンセル（空白時間最小）
+                - "cancel_first": 旧注文キャンセル → 新規注文発注（資金効率優先）
+
+        Returns:
+            Order: 新規注文情報
+
+        Raises:
+            APIError: API呼び出しに失敗
+        """
+        async with self._lock:
+            logger.info(
+                f"Repositioning order: old_order_id={old_order_id}, "
+                f"new_price={new_price:.2f}, strategy={strategy}"
+            )
+
+            if strategy == "place_first":
+                # 発注先行: 空白時間ゼロ
+                new_order = await self._place_order_unlocked(side, new_price, size)
+
+                # 新規注文が成功した場合のみ、旧注文をキャンセル
+                if new_order.status == OrderStatus.OPEN:
+                    await self._cancel_order_unlocked(old_order_id)
+                    logger.info(f"Reposition completed (place_first): new_order_id={new_order.id}")
+                else:
+                    logger.warning(
+                        f"New order not OPEN (status={new_order.status}), old order not cancelled"
+                    )
+
+                return new_order
+
+            else:  # cancel_first
+                # キャンセル先行: 資金効率優先
+                await self._cancel_order_unlocked(old_order_id)
+                new_order = await self._place_order_unlocked(side, new_price, size)
+
+                logger.info(f"Reposition completed (cancel_first): new_order_id={new_order.id}")
+
+                return new_order
+
+    async def _place_order_unlocked(
+        self,
+        side: Side,
+        price: float,
+        size: float,
+    ) -> Order:
+        """
+        注文を発注（ロックなし、内部使用専用）.
+
+        Args:
+            side: 注文サイド
+            price: 注文価格
+            size: 注文サイズ
+
+        Returns:
+            Order: 発注された注文情報
+        """
+        response = await self.client.new_order(
+            symbol=self.config.symbol,
+            side=side.value.lower(),
+            price=price,
+            size=size,
+            order_type="limit",
+            time_in_force="alo",
+            reduce_only=False,
+        )
+
+        return self._parse_order_response(response, side, price, size)
+
+    async def _cancel_order_unlocked(self, order_id: str) -> None:
+        """
+        注文をキャンセル（ロックなし、内部使用専用）.
+
+        Args:
+            order_id: キャンセルする注文ID
+        """
+        await self.client.cancel_order(
+            order_id=order_id,
+            symbol=self.config.symbol,
+        )
+
+    def _parse_order_response(
+        self,
+        response: dict[str, Any],
+        side: Side,
+        price: float,
+        size: float,
+    ) -> Order:
+        """
+        API レスポンスを Order オブジェクトにパース.
+
+        Args:
+            response: API レスポンス
+            side: 注文サイド
+            price: 注文価格
+            size: 注文サイズ
+
+        Returns:
+            Order: パースされた注文情報
+        """
+        # StandX APIのレスポンス形式:
+        # {"code": 0, "message": "success", "request_id": "xxx"}
+        # または
+        # {"order_id": "xxx", "status": "OPEN", ...}
+
+        # order_id を取得（レスポンス形式によって異なる可能性がある）
+        order_id = response.get("order_id") or response.get("request_id", "unknown")
+
+        # status を取得（デフォルトはOPEN）
+        status_str = response.get("status", "OPEN")
+        try:
+            status = OrderStatus(status_str)
+        except ValueError:
+            status = OrderStatus.OPEN
+
+        return Order(
+            id=order_id,
+            symbol=self.config.symbol,
+            side=side,
+            price=price,
+            size=size,
+            order_type=OrderType.LIMIT,
+            status=status,
+        )

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -1,0 +1,349 @@
+"""注文管理モジュールのテスト."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from standx_mm_bot.client import StandXHTTPClient
+from standx_mm_bot.config import Settings
+from standx_mm_bot.core.order import OrderManager
+from standx_mm_bot.models import OrderStatus, Side
+
+
+@pytest.fixture
+def config() -> Settings:
+    """テスト用設定."""
+    return Settings(
+        standx_private_key="0x" + "a" * 64,
+        standx_wallet_address="0x1234567890abcdef",
+        standx_chain="bsc",
+        symbol="ETH-USD",
+        order_size=0.001,
+    )
+
+
+@pytest.fixture
+def mock_client() -> Mock:
+    """モックHTTPクライアント."""
+    client = Mock(spec=StandXHTTPClient)
+    client.new_order = AsyncMock()
+    client.cancel_order = AsyncMock()
+    return client
+
+
+class TestPlaceOrder:
+    """place_order のテスト."""
+
+    @pytest.mark.asyncio
+    async def test_place_order_success(self, mock_client: Mock, config: Settings) -> None:
+        """注文発注が成功することを確認."""
+        # モックレスポンス
+        mock_client.new_order.return_value = {
+            "order_id": "test123",
+            "status": "OPEN",
+        }
+
+        order_mgr = OrderManager(mock_client, config)
+        order = await order_mgr.place_order(
+            side=Side.BUY,
+            price=3500.0,
+            size=0.001,
+        )
+
+        # 注文情報の確認
+        assert order.id == "test123"
+        assert order.symbol == "ETH-USD"
+        assert order.side == Side.BUY
+        assert order.price == 3500.0
+        assert order.size == 0.001
+        assert order.status == OrderStatus.OPEN
+
+        # API呼び出しの確認
+        mock_client.new_order.assert_called_once_with(
+            symbol="ETH-USD",
+            side="buy",
+            price=3500.0,
+            size=0.001,
+            order_type="limit",
+            time_in_force="alo",
+            reduce_only=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_place_order_with_request_id(self, mock_client: Mock, config: Settings) -> None:
+        """request_idのみのレスポンスでも動作することを確認."""
+        # レスポンスにorder_idがない場合
+        mock_client.new_order.return_value = {
+            "code": 0,
+            "message": "success",
+            "request_id": "req456",
+        }
+
+        order_mgr = OrderManager(mock_client, config)
+        order = await order_mgr.place_order(
+            side=Side.SELL,
+            price=3600.0,
+            size=0.001,
+        )
+
+        # request_idがorder_idとして使われる
+        assert order.id == "req456"
+        assert order.side == Side.SELL
+        assert order.status == OrderStatus.OPEN  # デフォルト
+
+
+class TestCancelOrder:
+    """cancel_order のテスト."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_order_success(self, mock_client: Mock, config: Settings) -> None:
+        """注文キャンセルが成功することを確認."""
+        mock_client.cancel_order.return_value = {"status": "CANCELLED"}
+
+        order_mgr = OrderManager(mock_client, config)
+        await order_mgr.cancel_order("test123")
+
+        # API呼び出しの確認
+        mock_client.cancel_order.assert_called_once_with(
+            order_id="test123",
+            symbol="ETH-USD",
+        )
+
+
+class TestRepositionOrder:
+    """reposition_order のテスト."""
+
+    @pytest.mark.asyncio
+    async def test_reposition_place_first(self, mock_client: Mock, config: Settings) -> None:
+        """発注先行の再配置が正しく動作することを確認."""
+        # 新規注文のレスポンス
+        mock_client.new_order.return_value = {
+            "order_id": "new123",
+            "status": "OPEN",
+        }
+        mock_client.cancel_order.return_value = {"status": "CANCELLED"}
+
+        order_mgr = OrderManager(mock_client, config)
+        new_order = await order_mgr.reposition_order(
+            old_order_id="old123",
+            new_price=3550.0,
+            side=Side.BUY,
+            size=0.001,
+            strategy="place_first",
+        )
+
+        # 新規注文情報の確認
+        assert new_order.id == "new123"
+        assert new_order.price == 3550.0
+
+        # 呼び出し順序の確認
+        assert mock_client.new_order.call_count == 1
+        assert mock_client.cancel_order.call_count == 1
+
+        # 発注が先に呼ばれたことを確認
+        call_order = list(mock_client.method_calls)
+        new_order_call = next(i for i, call in enumerate(call_order) if call[0] == "new_order")
+        cancel_call = next(i for i, call in enumerate(call_order) if call[0] == "cancel_order")
+        assert new_order_call < cancel_call
+
+    @pytest.mark.asyncio
+    async def test_reposition_cancel_first(self, mock_client: Mock, config: Settings) -> None:
+        """キャンセル先行の再配置が正しく動作することを確認."""
+        mock_client.new_order.return_value = {
+            "order_id": "new456",
+            "status": "OPEN",
+        }
+        mock_client.cancel_order.return_value = {"status": "CANCELLED"}
+
+        order_mgr = OrderManager(mock_client, config)
+        new_order = await order_mgr.reposition_order(
+            old_order_id="old456",
+            new_price=3450.0,
+            side=Side.SELL,
+            size=0.001,
+            strategy="cancel_first",
+        )
+
+        # 新規注文情報の確認
+        assert new_order.id == "new456"
+        assert new_order.price == 3450.0
+
+        # 呼び出し順序の確認
+        call_order = list(mock_client.method_calls)
+        cancel_call = next(i for i, call in enumerate(call_order) if call[0] == "cancel_order")
+        new_order_call = next(i for i, call in enumerate(call_order) if call[0] == "new_order")
+        assert cancel_call < new_order_call
+
+    @pytest.mark.asyncio
+    async def test_reposition_new_order_not_open(self, mock_client: Mock, config: Settings) -> None:
+        """新規注文がOPENでない場合、旧注文がキャンセルされないことを確認."""
+        # 新規注文が失敗（FILLED）
+        mock_client.new_order.return_value = {
+            "order_id": "new789",
+            "status": "FILLED",
+        }
+
+        order_mgr = OrderManager(mock_client, config)
+        new_order = await order_mgr.reposition_order(
+            old_order_id="old789",
+            new_price=3500.0,
+            side=Side.BUY,
+            size=0.001,
+            strategy="place_first",
+        )
+
+        # 新規注文は返される
+        assert new_order.id == "new789"
+        assert new_order.status == OrderStatus.FILLED
+
+        # 旧注文はキャンセルされない
+        assert mock_client.cancel_order.call_count == 0
+
+
+class TestConcurrency:
+    """並行処理のテスト."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_place_orders(self, mock_client: Mock, config: Settings) -> None:
+        """複数の注文を同時に発注しても競合しないことを確認."""
+        call_order = []
+
+        async def mock_new_order(*_args, **_kwargs):
+            call_order.append("start")
+            await asyncio.sleep(0.01)
+            call_order.append("end")
+            return {"order_id": f"order{len(call_order)}", "status": "OPEN"}
+
+        mock_client.new_order.side_effect = mock_new_order
+
+        order_mgr = OrderManager(mock_client, config)
+
+        # 3つの注文を同時に発注
+        orders = await asyncio.gather(
+            order_mgr.place_order(Side.BUY, 3500.0, 0.001),
+            order_mgr.place_order(Side.BUY, 3510.0, 0.001),
+            order_mgr.place_order(Side.BUY, 3520.0, 0.001),
+        )
+
+        # 全て成功
+        assert len(orders) == 3
+
+        # Lockにより順序が保証される（インターリーブしない）
+        assert call_order == [
+            "start",
+            "end",
+            "start",
+            "end",
+            "start",
+            "end",
+        ]
+
+
+# ========================================
+# 統合テスト（実API使用、手動実行）
+# ========================================
+
+
+@pytest.fixture
+def real_config() -> Settings:
+    """実際の.envから設定を読み込む."""
+    return Settings()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_place_and_cancel_order_real(real_config: Settings) -> None:
+    """
+    実注文テスト: 注文発注 → キャンセル.
+
+    前提条件:
+    - StandXに$10以上入金済み
+    - ORDER_SIZE=0.001
+
+    手順:
+    1. 現在価格を取得
+    2. 約定しない価格で注文発注（30bps離す）
+    3. 即座にキャンセル（1秒以内）
+    4. Position=0を確認
+    """
+    async with StandXHTTPClient(real_config) as client:
+        # 現在価格を取得
+        price_data = await client.get_symbol_price(real_config.symbol)
+        mark_price = float(price_data["mark_price"])
+
+        # 約定しない価格（BUY: 3%下、SELL: 3%上）
+        far_buy_price = round(mark_price * 0.97, 2)
+
+        order_mgr = OrderManager(client, real_config)
+
+        # 注文発注
+        order = await order_mgr.place_order(
+            side=Side.BUY,
+            price=far_buy_price,
+            size=0.001,
+        )
+
+        assert order.id is not None
+        assert order.status == OrderStatus.OPEN
+
+        # 即座にキャンセル
+        await asyncio.sleep(0.5)
+        await order_mgr.cancel_order(order.id)
+
+        # Position確認
+        position = await client.get_position(real_config.symbol)
+        if isinstance(position, list):
+            assert len(position) == 0, "Position should be empty"
+        else:
+            assert float(position.get("size", 0)) == 0, "Position size should be 0"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_reposition_order_real(real_config: Settings) -> None:
+    """
+    実注文テスト: 注文再配置.
+
+    手順:
+    1. 遠い価格で初回注文
+    2. 別の遠い価格に再配置
+    3. 両方キャンセル
+    4. Position=0を確認
+    """
+    async with StandXHTTPClient(real_config) as client:
+        # 現在価格を取得
+        price_data = await client.get_symbol_price(real_config.symbol)
+        mark_price = float(price_data["mark_price"])
+
+        # 約定しない価格
+        far_price_1 = round(mark_price * 0.97, 2)
+        far_price_2 = round(mark_price * 0.96, 2)
+
+        order_mgr = OrderManager(client, real_config)
+
+        # 初回注文
+        order1 = await order_mgr.place_order(Side.BUY, far_price_1, 0.001)
+        await asyncio.sleep(0.5)
+
+        # 再配置
+        order2 = await order_mgr.reposition_order(
+            old_order_id=order1.id,
+            new_price=far_price_2,
+            side=Side.BUY,
+            size=0.001,
+            strategy="place_first",
+        )
+
+        assert order2.id != order1.id
+        await asyncio.sleep(0.5)
+
+        # クリーンアップ
+        await order_mgr.cancel_order(order2.id)
+
+        # Position確認
+        position = await client.get_position(real_config.symbol)
+        if isinstance(position, list):
+            assert len(position) == 0
+        else:
+            assert float(position.get("size", 0)) == 0


### PR DESCRIPTION
## 概要

Phase 3-2: 注文管理（core/order.py）を実装しました。

Closes #17

---

## 実装内容

### 1. OrderManager クラス

**src/standx_mm_bot/core/order.py**

#### メソッド

- `place_order()`: 注文発注
  - **ALO (Add Liquidity Only)** 対応（`time_in_force='alo'`）
  - Maker注文専用（即座に約定しない）
  - asyncio.Lock による競合防止

- `cancel_order()`: 注文キャンセル
  - 安全なキャンセル処理
  - asyncio.Lock による競合防止

- `reposition_order()`: 注文再配置
  - **発注先行（place_first）**: 新規注文発注 → 確認 → 旧注文キャンセル
    - 空白時間ゼロ（Maker Uptime最大化）
  - **キャンセル先行（cancel_first）**: 旧注文キャンセル → 新規注文発注
    - 資金効率優先

### 2. http.py 修正

- `time_in_force` コメント更新: `(gtc/ioc/fok)` → `(gtc/ioc/alo)`

### 3. テスト実装

**tests/test_order.py**

- **モックテスト（7件）**:
  - 注文発注の成功
  - request_idのみのレスポンス対応
  - 注文キャンセル
  - 再配置（発注先行・キャンセル先行）
  - 新規注文失敗時の旧注文保護
  - 並行処理の競合防止

- **統合テスト（2件）**:
  - 実注文発注 → キャンセル
  - 実注文再配置
  - ※手動実行のみ（`@pytest.mark.integration`）

---

## テスト結果

```
✅ Format: 23 files formatted
✅ Lint: All checks passed
✅ Type check: Success (12 source files)
✅ Tests: 86 passed (7 new tests added)
✅ Coverage: 74% overall, 96% for order.py
```

---

## ALO (Add Liquidity Only) について

StandX APIの `time_in_force='alo'` を使用：

- ✅ 即座に約定しない（book without immediate execution）
- ✅ Maker注文のみ（only executes as resting order）
- ✅ Taker注文として約定しない

→ Botの設計思想「約定させない」に完璧に適合

---

## チェックリスト

- [x] OrderManager クラスが実装されている
- [x] place_order() が実装されている
- [x] cancel_order() が実装されている
- [x] reposition_order() が実装されている（発注先行・キャンセル先行）
- [x] asyncio.Lock が正しく使われている
- [x] ユニットテスト: test_order.py (7件)
- [x] 統合テスト: test_order.py (2件)
- [x] 全テストがパス
- [x] 型チェック・Lintエラーなし
- [x] カバレッジ 96%

---

## 次のステップ

- Phase 3-3: 厳格モードの実装（core/risk.py）#18
- Phase 4: 戦略統合（strategy/maker.py + __main__.py）#19